### PR TITLE
Add preset views

### DIFF
--- a/presentation.html
+++ b/presentation.html
@@ -1,23 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-	<title>PZ Present</title>
-    <script src="svg-pan-zoom.js"></script>
+  	<title>PZ Present</title>
   </head>
 
   <body>
     <embed id="mindmap" type="image/svg+xml" style="width: 100%; height: 100%; " src="presentation.svg" />
 
-    <script>
-      // Don't use window.onLoad like this in production, because it can only listen to one function.
-      window.onload = function() {
-        svgPanZoom('#mindmap', {
-          zoomEnabled: true,
-          controlIconsEnabled: false
-        });
-      };
-    </script>
-
+    <script src="svg-pan-zoom.js"></script>
+    <script src="views.js"></script>
+    <script src="pz_present.js"></script>
   </body>
 
 </html>

--- a/pz_present.js
+++ b/pz_present.js
@@ -1,5 +1,6 @@
 // The svgPanZoom object instance.
 var svgpz;
+var currentView = 0;
 
 window.addEventListener(
   'load',
@@ -45,17 +46,28 @@ function getViewIndexByKeyName(keyName, views) {
 function keyListener(event) {
   var keyName = event.key;
   var keyNameNum = Number(keyName);
+  var previousView = currentView;
 
-  if (keyNameNum === 0) {
-    svgpz.reset();
-  } else if (keyNameNum >= 1 && keyNameNum <= 9 && views[keyNameNum]) {
-    zoomAndPan(views[keyNameNum]);
-  } else if (keyName === '.') {
+  if (keyName === '.') {
     console.log(getZoomAndPan().join(', '));
+  } else if (keyNameNum >= 0 && keyNameNum <= 9 && views[keyNameNum]) {
+    currentView = keyNameNum;
+  } else if (keyName === 'ArrowRight' && currentView < views.length - 1) {
+    currentView += 1;
+  } else if (keyName === 'ArrowLeft' && currentView > 0) {
+    currentView -= 1;
   } else {
     var index = getViewIndexByKeyName(keyName, views);
     if (index !== -1) {
-      zoomAndPan(views[index]);
+      currentView = index;
+    }
+  }
+
+  if (currentView !== previousView) {
+    if (currentView === 0) {
+      svgpz.reset();
+    } else {
+      zoomAndPan(views[currentView]);
     }
   }
 }

--- a/pz_present.js
+++ b/pz_present.js
@@ -1,0 +1,63 @@
+// The svgPanZoom object instance.
+var svgpz;
+
+window.addEventListener(
+  'load',
+  function() {
+    svgpz = svgPanZoom('#mindmap', {
+      zoomEnabled: true,
+      controlIconsEnabled: false,
+    });
+  },
+  false
+);
+
+function getZoomAndPan() {
+  // The raw zoom and pan values are absolute, so we make them
+  // relative to the width and height of the SVG.  That way they
+  // still work when the window/screen is a different size.
+  var zoom = svgpz.getZoom();
+  var pan = svgpz.getPan();
+  var { width, height } = svgpz.getSizes();
+  var relPanX = pan.x / width;
+  var relPanY = pan.y / height;
+  return [zoom, relPanX, relPanY];
+}
+
+function zoomAndPan([zoomValue, panX, panY]) {
+  // The 2nd argument to zoom controls whether the zoom value
+  // is absolute (true) or relative (false, default).
+  svgpz.zoom(zoomValue, true);
+
+  var { width, height } = svgpz.getSizes();
+  svgpz.pan({
+    x: panX * width,
+    y: panY * height,
+  });
+}
+
+function getViewIndexByKeyName(keyName, views) {
+  return views.findIndex(function(view) {
+    return view[3] === keyName;
+  });
+}
+
+function keyListener(event) {
+  var keyName = event.key;
+  var keyNameNum = Number(keyName);
+
+  if (keyNameNum === 0) {
+    svgpz.reset();
+  } else if (keyNameNum >= 1 && keyNameNum <= 9 && views[keyNameNum]) {
+    zoomAndPan(views[keyNameNum]);
+  } else if (keyName === '.') {
+    console.log(getZoomAndPan().join(', '));
+  } else {
+    var index = getViewIndexByKeyName(keyName, views);
+    if (index !== -1) {
+      zoomAndPan(views[index]);
+    }
+  }
+}
+
+document.addEventListener('keydown', keyListener, false);

--- a/views.js
+++ b/views.js
@@ -1,0 +1,12 @@
+// Each view is: [zoom, panX, panY, keyName]
+// The keyName is an optional shortcut key.
+// The first item is just a placeholder so a view's index matches
+// the number key that triggers that view.
+// The initial values below are just examples.
+
+var views = [
+  true,
+  [6.712530067616177, -0.45830959532128357, -0.511818406099308, 'o'],
+  [3.352579990458861, -0.9536514806419816, -0.9724587113680486, 'p'],
+  [2.2629697434789104, 0.17308933655966974, -0.6732205866811749],
+];


### PR DESCRIPTION
Add initial preset views functionality -- particular pan and zoom positions that you can jump to, currently via keyboard keys.  Views are triggered by number keys.  The zero key is the initial page view, the 1 key is the first preset view, etc.  Left and right arrow keys move back and forth through the views.  You can also optionally assign a letter key to a view (likely easier to remember than a number).  

For now, to generate coordinates for a view, pan and zoom to the view and hit the period ('.') key which will log the coordinates to the browser console.  Then cut and paste those coordinates into the array of views in the views.js file.  The plan is to add better support for saving views.